### PR TITLE
WIP on Issue 2

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -21,6 +21,7 @@ import logger from 'morgan'
 import cors from 'cors'
 import indexRouter from './index.mjs'
 import manifestRouter from './manifest/index.mjs'
+import projectRouter from './project/index.mjs'
 import * as logic from './manifest/manifest.mjs'
 
 let app = express()
@@ -34,22 +35,26 @@ app.use(cookieParser())
 //Publicly available scripts, CSS, and HTML pages.
 app.use(express.static(path.join(__dirname, 'public')))
 
-
 /**
  * For any request that comes through to the app, check whether or not we are in maintenance mode.
  * If we are, then respond with a 503 and a message.  Otherwise, continue on.
- */ 
+ */
 app.all('*', (req, res, next) => {
-  if(process.env.DOWN === "true"){
-      res.status(503).json({"message":"TPEN3 services are down for updates or maintenance at this time.  We apologize for the inconvenience.  Try again later."})
-  }
-  else{
-      next() //pass on to the next app.use
+  if (process.env.DOWN === 'true') {
+    res
+      .status(503)
+      .json({
+        message:
+          'TPEN3 services are down for updates or maintenance at this time.  We apologize for the inconvenience.  Try again later.',
+      })
+  } else {
+    next() //pass on to the next app.use
   }
 })
 
 app.use('/', indexRouter)
 app.use('/manifest', manifestRouter)
+app.use('/project', projectRouter)
 
 //catch 404 because of an invalid site path
 app.use(function(req, res, next) {

--- a/project/__tests__/end_to_end_unit.test.mjs
+++ b/project/__tests__/end_to_end_unit.test.mjs
@@ -1,0 +1,61 @@
+//need to import app for coverage, not for actual testing tho.
+//import app from '../../app.mjs'
+
+import {default as projectRouter} from '../index.mjs'
+import express from 'express'
+import request from 'supertest'
+
+const routeTester = new express()
+routeTester.use("/project", projectRouter)
+
+describe('Project endpoint end to end unit test (spinning up the endpoint and using it). #end2end_unit', () => {
+
+  it('POST instead of GET.  That status should be 405 with a message.', async () => {
+    const res = await request(routeTester)
+      .post('/project/')
+      expect(res.statusCode).toBe(405)
+      expect(res.body).toBeTruthy()
+  })
+
+  it('PUT instead of GET.  That status should be 405 with a message.', async () => {
+    const res = await request(routeTester)
+      .put('/project/')
+      expect(res.statusCode).toBe(405)
+      expect(res.body).toBeTruthy()
+  })
+
+  it('PATCH instead of GET.  That status should be 405 with a message.', async () => {
+    const res = await request(routeTester)
+      .patch('/project/')
+      expect(res.statusCode).toBe(405)
+      expect(res.body).toBeTruthy()
+  })
+
+  it('Call to /project without a TPEN3 project ID.  The status should be 400 with a message.', async () => {
+    const res = await request(routeTester)
+      .get('/project/')
+      expect(res.statusCode).toBe(400)
+      expect(res.body).toBeTruthy()
+  })
+
+  it('Call to /project with a TPEN3 project ID that does not exist.  The status should be 404 with a message.', async () => {
+    const res = await request(routeTester)
+      .get('/project/0001')
+      expect(res.statusCode).toBe(404)
+      expect(res.body).toBeTruthy()
+  })
+
+  it('Call to /project with a TPEN3 project ID that does  exist.  The status should be 200 with a JSON Project in the body.', async () => {
+    const res = await request(routeTester)
+      .get('/project/7085')
+      let json = res.body
+      try{
+        json = JSON.parse(JSON.stringify(json))
+      }
+      catch(err){
+        json = null
+      }
+      expect(json).not.toBe(null)
+  })
+  
+})

--- a/project/__tests__/exists_unit.test.mjs
+++ b/project/__tests__/exists_unit.test.mjs
@@ -1,0 +1,16 @@
+//need to import app for coverage, not for actual testing tho.
+import app from '../../app.mjs'
+
+describe('Project endpoint availability unit test (via a check on the app routes). #exists_unit', () => {
+  it('responds to /project/id', () => {
+    let exists = false
+    const stack = app._router.stack
+    for(const middleware of stack){
+      if(middleware.regexp && middleware.regexp.toString().includes("/project")) {
+         exists = true
+         break
+       } 
+    }
+    expect(exists).toBe(true)
+  })
+})

--- a/project/__tests__/functionality_unit.test.mjs
+++ b/project/__tests__/functionality_unit.test.mjs
@@ -1,0 +1,26 @@
+//need to import app for coverage, not for actual testing tho.
+import app from '../../app.mjs'
+// This is specifically the Project router and related util functions
+import {findTheProjectByID} from '../project.mjs'
+import {validateProjectID} from '../../utilities/shared.mjs'
+
+// These test the pieces of functionality in the route that make it work.
+describe('Project endpoint functionality unit test (just testing helper functions). #functions_unit', () => {
+
+  it('No TPEN3 project id provided.  Project validation must be false.', () => {
+    expect(validateProjectID()).toBe(false)
+  })
+  it('Detect TPEN3 project does not exist.  The query for a TPEN3 project must be null.', async () => {
+    const project = await findTheProjectByID(-111)
+    expect(project).toBe(null)
+  })
+  it('TPEN3 project does exist.  Finding the project results in the project JSON', async () => {
+    let project = await findTheProjectByID(7085)
+    expect(project).not.toBe(null)
+  })
+
+})
+
+// If you are doing just findTheProjectById, but you screw up the route, that won't be detected here.
+// The end to end test would fail, this would succeed.  You now have a very narrow band to look at.
+// It is worth having both, but removing the redundant test 

--- a/project/index.mjs
+++ b/project/index.mjs
@@ -1,0 +1,72 @@
+/** Route handler for the /project endpoint */
+
+import express from 'express'
+import * as logic from './project.mjs'
+import * as utils from '../utilities/shared.mjs'
+import cors from 'cors'
+
+let router = express.Router()
+router.use(
+  cors({
+    methods: 'GET',
+    allowedHeaders: [
+      'Content-Type',
+      'Content-Length',
+      'Allow',
+      'Authorization',
+      'Location',
+      'ETag',
+      'Connection',
+      'Keep-Alive',
+      'Date',
+      'Cache-Control',
+      'Last-Modified',
+      'Link',
+      'X-HTTP-Method-Override',
+    ],
+    exposedHeaders: '*',
+    origin: '*',
+    maxAge: '600',
+  })
+)
+
+// Send a successful response with the appropriate JSON
+export function respondWithProject(res, project) {
+  const id = project['@id'] ?? project.id ?? null
+  res.set('Content-Type', 'application/json; charset=utf-8')
+  res.location(id)
+  res.status(200)
+  res.json(project)
+}
+
+// Expect an /{id} as part of the route, like /project/123
+router
+  .route('/:id')
+  .get(async (req, res, next) => {
+    let id = req.params.id
+    if (!utils.validateProjectID(id)) {
+      utils.respondWithError(res, 400, 'The TPEN3 project ID must be a number')
+    }
+    id = parseInt(id)
+    const projectObj = await logic.findTheProjectByID(id)
+    if (projectObj) {
+      respondWithProject(res, projectObj)
+    } else {
+      utils.respondWithError(res, 404, `TPEN 3 project "${req.params.id}" does not exist.`)
+    }
+  })
+  .all((req, res, next) => {
+    utils.respondWithError(res, 405, 'Improper request method, please use GET.')
+  })
+
+// Handle lack of an /{id} as part of the route
+router
+  .route('/')
+  .get((req, res, next) => {
+    utils.respondWithError(res, 400, 'Improper request.  There was no project ID.')
+  })
+  .all((req, res, next) => {
+    utils.respondWithError(res, 405, 'Improper request method, please use GET.')
+  })
+
+export { router as default }

--- a/project/project.mjs
+++ b/project/project.mjs
@@ -1,6 +1,7 @@
 /** Logic for the /project endpoint */
 
 import * as utils from '../utilities/shared.mjs'
+import * as fs from 'fs'
 
 export async function findTheProjectByID(id = null) {
   let project = null
@@ -14,12 +15,13 @@ export async function findTheProjectByID(id = null) {
   })
 
   if (id && id === 7085) {
-    project = await fetch('https://t-pen.org/TPEN/manifest/7085')
-      .then((resp) => resp.json())
-      .catch((err) => {
+    let projectFileBuffer = fs.readFileSync('./public/project.json', (err, data) => {
+      if (err) {
         console.error(err)
         return null
-      })
+      }
+    })
+    project = projectFileBuffer !== null && JSON.parse(projectFileBuffer.toString())
   }
 
   // Mock the scenario where it takes a couple seconds to look for but not find the Project.

--- a/project/project.mjs
+++ b/project/project.mjs
@@ -26,9 +26,7 @@ export async function findTheProjectByID(id = null) {
 
   // Mock the scenario where it takes a couple seconds to look for but not find the Project.
   if (project === null) {
-    project = mockPause.then((val) => {
-      return null
-    })
+    project = await mockPause
   }
   return project
 }

--- a/project/project.mjs
+++ b/project/project.mjs
@@ -1,0 +1,32 @@
+/** Logic for the /project endpoint */
+
+import * as utils from '../utilities/shared.mjs'
+
+export async function findTheProjectByID(id = null) {
+  let project = null
+  if (!utils.validateProjectID(id)) return project
+
+  // Mock a pause for endpoints that fail, to mock the time it takes for some async stuff to decide it failed.
+  const mockPause = new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve(null)
+    }, 1500)
+  })
+
+  if (id && id === 7085) {
+    project = await fetch('https://t-pen.org/TPEN/manifest/7085')
+      .then((resp) => resp.json())
+      .catch((err) => {
+        console.error(err)
+        return null
+      })
+  }
+
+  // Mock the scenario where it takes a couple seconds to look for but not find the Project.
+  if (project === null) {
+    project = mockPause.then((val) => {
+      return null
+    })
+  }
+  return project
+}

--- a/public/project.json
+++ b/public/project.json
@@ -1,0 +1,42 @@
+{
+   "@context":"http://iiif.io/api/presentation/2/context.json",
+   "@id":"https://t-pen.org/TPEN/manifest/7085/manifest.json",
+   "@type":"sc:Manifest",
+   "label":"Ct Interlinear Glosses Mt 5",
+   "metadata":[
+      {
+         "label":"title",
+         "value":"TPEN3 Test Manifest"
+      }
+   ],
+   "sequences":[
+      {
+         "@id":"https://t-pen.org/TPEN/manifest/7085/sequence/normal",
+         "@type":"sc:Sequence",
+         "label":"Current Page Order",
+         "canvases":[
+            {
+               "@id":"https://t-pen.org/TPEN/canvas/13248868",
+               "@type":"sc:Canvas",
+               "label":"f010v-f011r",
+               "width":1320,
+               "height":1000,
+               "images":[
+                  {
+                     "@type":"oa:Annotation",
+                     "motivation":"sc:painting",
+                     "resource":{
+                        "@id":"https://trin-digital-library.trin.cam.ac.uk/iiif/2/B.1.10%2F013_B.1.10_f010v-f011r.jpg/full/full/0/default.jpg",
+                        "@type":"dctypes:Image",
+                        "format":"image/jpeg",
+                        "width":4136,
+                        "height":3131
+                     },
+                     "on":"https://t-pen.org/TPEN/canvas/13248868"
+                  }
+               ]
+            }
+         ]
+      }
+   ]
+}


### PR DESCRIPTION
* Added 'project' directory mirroring the structure of the existing 'manifest' directory, including files and tests
* Added project.json to 'public' directory, with the same dummy data as manifest.json
* Dummy data is loaded from the project.json file instead of the TPEN website

* After running `npm start`, navigating to http://localhost:3001/project/{project_id_here} will test out the functionality.
* As of now, functionality is largely mirrored from the /manifest endpoint. http://localhost/project/7085 loads dummy data from the project.json file, and any other URLs result in appropriate error messages.
* `npm run unitTests` runs the new tests, which currently test the same basic functionality as the tests for /manifest