### PR TITLE
Dashboard service for newest, last modified, last opened projects

### DIFF
--- a/classes/Project/ProjectStats.mjs
+++ b/classes/Project/ProjectStats.mjs
@@ -1,0 +1,41 @@
+// classes/Project/ProjectStats.mjs
+import dbDriver from "../../database/driver.mjs"
+
+const database = new dbDriver("mongo")
+const STATS_COLL =  process.env.TPEN_USER_PROJECT_STATS
+
+export default class ProjectStats {
+    /**
+     * Record that `userId` just opened `projectId`.
+     * If a stat exists, update its lastOpened; otherwise insert a new one.
+     */
+    static async recordOpen(userId, projectId) {
+        const query = { userId, projectId }
+        const now = new Date()
+
+        // see if there's already a stat doc
+        const existing = await database.findOne(query, STATS_COLL)
+
+        if (existing) {
+            existing.lastOpened = now
+            // update by _id under the hood
+            await database.update(existing, STATS_COLL)
+            return existing
+        } else {
+            const stat = { userId, projectId, lastOpened: now }
+            await database.save(stat, STATS_COLL)
+            return stat
+        }
+    }
+
+    /**
+     * Fetch up to `limit` stats for this user, sorted by lastOpened descending.
+     * We pull all then sort/limit in memory.
+     */
+    static async getLastOpened(userId, limit = 1) {
+        const stats = await database.find({ userId }, STATS_COLL)
+        // sort descending by lastOpened timestamp
+        stats.sort((a, b) => new Date(b.lastOpened) - new Date(a.lastOpened))
+        return stats.slice(0, limit)
+    }
+}

--- a/classes/Project/ProjectStats.mjs
+++ b/classes/Project/ProjectStats.mjs
@@ -1,41 +1,76 @@
-// classes/Project/ProjectStats.mjs
 import dbDriver from "../../database/driver.mjs"
+import User from "../User/User.mjs"
 
 const database = new dbDriver("mongo")
-const STATS_COLL =  process.env.TPEN_USER_PROJECT_STATS
+const PROJECT_COLL = process.env.TPENPROJECTS
+const STATS_COLL = process.env.TPEN_USER_PROJECT_STATS
 
 export default class ProjectStats {
-    /**
-     * Record that `userId` just opened `projectId`.
-     * If a stat exists, update its lastOpened; otherwise insert a new one.
-     */
+
+    // upsert lastOpened 
     static async recordOpen(userId, projectId) {
-        const query = { userId, projectId }
         const now = new Date()
-
-        // see if there's already a stat doc
-        const existing = await database.findOne(query, STATS_COLL)
-
+        const existing = await database.findOne({ userId }, STATS_COLL)
         if (existing) {
+            existing.projectId = projectId
             existing.lastOpened = now
-            // update by _id under the hood
-            await database.update(existing, STATS_COLL)
-            return existing
-        } else {
-            const stat = { userId, projectId, lastOpened: now }
-            await database.save(stat, STATS_COLL)
-            return stat
+            return database.update(existing, STATS_COLL)
         }
+        return database.save({ userId, projectId, lastOpened: now }, STATS_COLL)
     }
 
-    /**
-     * Fetch up to `limit` stats for this user, sorted by lastOpened descending.
-     * We pull all then sort/limit in memory.
-     */
-    static async getLastOpened(userId, limit = 1) {
-        const stats = await database.find({ userId }, STATS_COLL)
-        // sort descending by lastOpened timestamp
-        stats.sort((a, b) => new Date(b.lastOpened) - new Date(a.lastOpened))
-        return stats.slice(0, limit)
+    // helper to get IDs of projects user can access
+    static async _getAccessibleIds(userId) {
+        const projects = await new User(userId).getProjects()
+        return projects.map(project => project._id)
+    }
+
+    // newest by creation time
+    static async getNewest(userId) {
+        const ids = await this._getAccessibleIds(userId)
+        const coll = database.controller.db.collection(PROJECT_COLL)
+        const [doc] = await coll
+            .find({ _id: { $in: ids } })
+            .project({ _id: 1, label: 1 })
+            .sort({ _createdAt: -1 })
+            .limit(1)
+            .toArray()
+        return doc ?? null
+    }
+
+    // most recently modified
+    static async getLastModified(userId) {
+        const ids = await this._getAccessibleIds(userId)
+        const coll = database.controller.db.collection(PROJECT_COLL)
+        const [doc] = await coll
+            .find({ _id: { $in: ids } })
+            .project({ _id: 1, label: 1 })
+            .sort({ _modifiedAt: -1 })
+            .limit(1)
+            .toArray()
+        return doc ?? null
+    }
+
+    // last opened (single‐doc per user)
+    static async getLastOpened(userId) {
+        const stat = await database.findOne({ userId }, STATS_COLL)
+        if (!stat) return null
+        const coll = database.controller.db.collection(PROJECT_COLL)
+        const [doc] = await coll
+            .find({ _id: stat.projectId })
+            .project({ _id: 1, label: 1 })
+            .limit(1)
+            .toArray()
+        return doc ?? null
+    }
+
+    // bundle all three into one call
+    static async getDashboard(userId) {
+        const [newest, lastModified, lastOpened] = await Promise.all([
+            this.getNewest(userId),
+            this.getLastModified(userId),
+            this.getLastOpened(userId)
+        ])
+        return { newest, lastModified, lastOpened }
     }
 }


### PR DESCRIPTION
This PR centralizes all of the “newest / last modified / last opened” project‐lookup logic into a new `ProjectStats` class and creates the `/projects/dashboard` route as a single service call. It also records “last opened” timestamps in ProjectStats.recordOpen whenever a user fetches a project using `project/:id`.
Returned objects contain projectId and label.