### PR TITLE
Set line creator if not already defined

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1787,9 +1787,9 @@
          "license": "MIT"
       },
       "node_modules/brace-expansion": {
-         "version": "1.1.11",
-         "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-         "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+         "version": "1.1.12",
+         "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+         "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -2539,6 +2539,21 @@
             "node": ">= 0.4"
          }
       },
+      "node_modules/es-set-tostringtag": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+         "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+         "license": "MIT",
+         "dependencies": {
+            "es-errors": "^1.3.0",
+            "get-intrinsic": "^1.2.6",
+            "has-tostringtag": "^1.0.2",
+            "hasown": "^2.0.2"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         }
+      },
       "node_modules/escalade": {
          "version": "3.2.0",
          "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -2821,13 +2836,15 @@
          }
       },
       "node_modules/form-data": {
-         "version": "4.0.1",
-         "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-         "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+         "version": "4.0.4",
+         "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+         "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
          "license": "MIT",
          "dependencies": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
+            "es-set-tostringtag": "^2.1.0",
+            "hasown": "^2.0.2",
             "mime-types": "^2.1.12"
          },
          "engines": {
@@ -3045,6 +3062,21 @@
          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
          "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
          "license": "MIT",
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/has-tostringtag": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+         "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+         "license": "MIT",
+         "dependencies": {
+            "has-symbols": "^1.0.3"
+         },
          "engines": {
             "node": ">= 0.4"
          },
@@ -4515,16 +4547,16 @@
          }
       },
       "node_modules/morgan": {
-         "version": "1.10.0",
-         "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-         "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+         "version": "1.10.1",
+         "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
+         "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
          "license": "MIT",
          "dependencies": {
             "basic-auth": "~2.0.1",
             "debug": "2.6.9",
             "depd": "~2.0.0",
             "on-finished": "~2.3.0",
-            "on-headers": "~1.0.2"
+            "on-headers": "~1.1.0"
          },
          "engines": {
             "node": ">= 0.8.0"
@@ -4806,9 +4838,9 @@
          }
       },
       "node_modules/on-headers": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-         "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+         "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
          "license": "MIT",
          "engines": {
             "node": ">= 0.8"

--- a/page/index.js
+++ b/page/index.js
@@ -99,6 +99,7 @@ router.route('/:pageId')
           const line = item.id?.startsWith?.('http')
             ? new Line(item)
             : Line.build(projectId, pageId, item, user.agent.split('/').pop())
+          line.creator ??= user.agent.split('/').pop()
           return await line.update()
         }))
       }


### PR DESCRIPTION
Adds logic to assign the line's creator property to the user's agent if it is undefined when processing items. This ensures that the creator information is consistently set for new or updated lines.