### PR TITLE
Protect /project/create from suspicious input

### DIFF
--- a/project/projectCreateRouter.js
+++ b/project/projectCreateRouter.js
@@ -8,7 +8,7 @@ import screenContentMiddleware from "../utilities/checkIfSuspicious.js"
 
 const router = express.Router({ mergeParams: true })
 
-router.route("/create").post(auth0Middleware(), async (req, res) => {
+router.route("/create").post(auth0Middleware(), screenContentMiddleware(), async (req, res) => {
   const user = req.user
   if (!user?.agent) return respondWithError(res, 401, "Unauthenticated user")
   const projectObj = new Project()


### PR DESCRIPTION
Protect the POST /project/create route by adding screenContentMiddleware from utilities/checkIfSuspicious.js to validate and block suspicious body content before project creation. This helps prevent code-like injection in user-provided fields.

- Route: project/projectCreateRouter.js (POST /create)
- Middleware: screenContentMiddleware()
- Behavior: Responds with 400 "Suspicious input will not be processed." when input appears code-like or injected
- Notes: Aligns with existing protection on /:projectId/label

Branch: 312-protect-create-route
Target: development
Tests: No test changes in this PR.