### PR TITLE
Protect PUT /profile route

### DIFF
--- a/userProfile/privateProfile.js
+++ b/userProfile/privateProfile.js
@@ -24,7 +24,7 @@ router.route("/profile").get(auth0Middleware(), async (req, res) => {
   if (!user) return respondWithError(res, 401, "Unauthorized user")
   try {
     if (req.body && !Array.isArray(req.body)) {
-      for (const key of req.body) {
+      for (const key in req.body) {
         if (isSuspiciousJSON(req.body[key]) || isSuspiciousValueString(req.body[key]))
           return respondWithError(res, 400, "Suspicious profile data will not be processed.")
       }


### PR DESCRIPTION
This endpoint takes the request body wholesale and adds it into the user object in the database under `profile`.  Keys and values are not limited in any way.  For the keys we expect (such as those found on the Manage Profile interface) they are not validated in any way.  See #330 