### PR TITLE
/page:pagid Fully Resolved - gpt-5.1-codex in Codex CLI

### DIFF
--- a/API.md
+++ b/API.md
@@ -379,12 +379,14 @@ Note that you may not empty the canvases of an existing layer.  If the `canvases
     
 #### `GET /project/:projectId/layer/:layerId/page/:pageid`
 #### `GET /project/:projectId/page/:pageid`
+#### `GET /project/:projectId/page/:pageid/resolved`
 
 - **Description**: Get an existing page within a project.
 - **Parameters**:
   - `projectId`: ID of the project.
   - `layerId`: Optional.  ID of the layer.
   - `pageId`: The ID of the page.
+  - `resolved`: Optional query parameter (`true|1|yes|resolved`) to embed referenced annotations and collections without using the `/resolved` path.
 
 - **Responses**:
 
@@ -405,4 +407,5 @@ Note that you may not empty the canvases of an existing layer.  If the `canvases
             "next": "string"
         }
         ```
+        - When requesting `/resolved` or `?resolved=true`, `items` include fully resolved Annotations (with bodies) and `partOf` collections are expanded inline.
     - **500**: Server error

--- a/page/__tests__/resolveAnnotationPage.test.js
+++ b/page/__tests__/resolveAnnotationPage.test.js
@@ -1,0 +1,52 @@
+import { jest } from '@jest/globals'
+import { resolveAnnotationPage } from '../resolveAnnotationPage.js'
+
+const ORIGINAL_FETCH = global.fetch
+
+describe('resolveAnnotationPage', () => {
+  beforeEach(() => {
+    process.env.RERUMIDPREFIX = 'https://devstore.rerum.io/v1/id/'
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        id: 'https://devstore.rerum.io/v1/id/anno1',
+        type: 'Annotation',
+        body: [{ type: 'TextualBody', value: 'hello' }]
+      })
+    }))
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    global.fetch = ORIGINAL_FETCH
+  })
+
+  it('embeds remote annotations referenced in items', async () => {
+    const page = {
+      '@context': 'http://www.w3.org/ns/anno.jsonld',
+      id: 'https://devstore.rerum.io/v1/id/page1',
+      type: 'AnnotationPage',
+      items: [{ id: 'https://devstore.rerum.io/v1/id/anno1', type: 'Annotation' }],
+      partOf: []
+    }
+
+    const resolved = await resolveAnnotationPage(page)
+
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    expect(resolved.items[0].body[0].value).toBe('hello')
+  })
+
+  it('throws when a referenced resource cannot be resolved', async () => {
+    global.fetch = jest.fn(async () => ({ ok: false, status: 404 }))
+    const page = {
+      '@context': 'http://www.w3.org/ns/anno.jsonld',
+      id: 'https://devstore.rerum.io/v1/id/page1',
+      type: 'AnnotationPage',
+      items: [{ id: 'https://devstore.rerum.io/v1/id/anno1', type: 'Annotation' }],
+      partOf: []
+    }
+
+    await expect(resolveAnnotationPage(page)).rejects.toThrow('Failed to resolve resource')
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/page/resolveAnnotationPage.js
+++ b/page/resolveAnnotationPage.js
@@ -1,0 +1,88 @@
+const RERUM_PREFIX = process.env.RERUMIDPREFIX ?? 'https://devstore.rerum.io/v1/id/'
+
+/**
+ * Attempt to resolve an AnnotationPage's referenced resources (Annotations, bodies, Collections)
+ * by fetching them from RERUM/TinyPEN when only an identifier is provided.
+ *
+ * @param {Object} annotationPage - A plain AnnotationPage JSON structure.
+ * @returns {Promise<Object>} Fully-resolved AnnotationPage JSON.
+ */
+export const resolveAnnotationPage = async annotationPage => {
+  if (!annotationPage || typeof annotationPage !== 'object') {
+    throw new Error('AnnotationPage payload is required to resolve references.')
+  }
+
+  const resolvedPage = structuredClone(annotationPage)
+  resolvedPage.items = await resolveAnnotations(resolvedPage.items ?? [])
+  resolvedPage.partOf = await resolveCollections(resolvedPage.partOf ?? [])
+  return resolvedPage
+}
+
+const resolveAnnotations = async items => Promise.all(items.map(async item => {
+  const resolved = await resolveReference(item, { resolveBodies: true })
+  if (!resolved?.body) return resolved
+  if (Array.isArray(resolved.body)) {
+    resolved.body = await Promise.all(resolved.body.map(resolveBodyNode))
+  } else {
+    resolved.body = await resolveBodyNode(resolved.body)
+  }
+  return resolved
+}))
+
+const resolveCollections = async collections => Promise.all(collections.map(col => resolveReference(col)))
+
+const resolveBodyNode = async node => {
+  if (!node) return node
+  if (Array.isArray(node)) {
+    return Promise.all(node.map(resolveBodyNode))
+  }
+  return resolveReference(node)
+}
+
+const resolveReference = async (resource, options = {}) => {
+  const { resolveBodies = false } = options
+  const resourceId = extractId(resource)
+  if (!resourceId || !shouldResolveId(resourceId)) return resource
+
+  const resolved = await fetchJson(resourceId)
+  const merged = (resource && typeof resource === 'object' && !Array.isArray(resource))
+    ? { ...resource, ...resolved }
+    : resolved
+
+  if (resolveBodies && merged.body) {
+    if (Array.isArray(merged.body)) {
+      merged.body = await Promise.all(merged.body.map(resolveBodyNode))
+    } else {
+      merged.body = await resolveBodyNode(merged.body)
+    }
+  }
+
+  return merged
+}
+
+const extractId = resource => {
+  if (!resource) return null
+  if (typeof resource === 'string') return resource
+  if (typeof resource === 'object') return resource.id ?? resource['@id'] ?? null
+  return null
+}
+
+const shouldResolveId = id => typeof id === 'string' && id.startsWith(RERUM_PREFIX)
+
+const fetchJson = async id => {
+  try {
+    const response = await fetch(id)
+    if (!response.ok) {
+      const error = new Error(`Failed to resolve resource ${id}`)
+      error.status = response.status ?? 502
+      throw error
+    }
+    return await response.json()
+  } catch (err) {
+    if (!err.status) err.status = 502
+    throw err
+  }
+}
+
+export default resolveAnnotationPage
+


### PR DESCRIPTION
Note that I activated it in "High Reasoning" mode for this task.

It took about 6 minutes for it to come up with a plan and get a bit of input for small changes to that plan.  It only took about 15 minutes to do the work.  Total cost was $0.90.

- At this point I don't believe it making it `git` itself anymore.  Best to do that yourself ahead of time, but I believe this one could have done it.
- I had to do the Draft PR, not totally convinced it would have done it.
- The feedback output in this was particularly tidy. 

```
 • Plan

  - Reconfirm rules: already reviewed .claude/CLAUDE.md (env bootstrap, testing expectations, JSDoc preference, manual validation via pm2 + curl) and issue
    #382 (work on 382-for-gpt-5.1-codex, draft PR back to 382-fully-resolved-page, npm run allTests must pass, manual e2e via http://localhost:3012 with
    provided Bearer token). Will keep standard GET behavior untouched while adding a resolved option.
  - Inspect existing flow (page/index.js, utilities/shared.js, TinyPEN controller) to understand how findPageById pulls from local projects vs RERUM. Decide
    on the surfaced contract: add a sibling route GET /project/:projectId/page/:pageId/resolved (preferred to avoid query-string hassles mentioned in issue)
    while also honoring a ?resolved=true flag on the original route for backwards compatibility. Both entry points should funnel into a shared controller to
    avoid duplication.
  - Build a resolution helper (e.g., resolveAnnotationPage(page) in a new utility module or inside page/index.js) that:
      1. Ensures we have the complete AnnotationPage JSON (for local pages, reuse current builder; for RERUM pages, use existing fetch logic).
      2. Normalizes items to an array of annotation objects by fetching any string/id references (use fetch directly like other routes or go through TinyPEN
         driver if needed for batching; guard with concurrency via Promise.allSettled so one failure can be surfaced cleanly).
      3. Resolves body entries that are URIs (recursively fetching nested resources when necessary) and embeds their JSON inside the annotation.
      4. Resolves every entry in partOf (AnnotationCollections) and, if needed, their items metadata so clients can navigate without another round trip.
      5. Adds defensive logging + RESTful error responses (404 for missing references, 502 for upstream failure, etc.) while returning partial data only
         when it is safe to do so.
  - Extend tests/documentation:
      - Add/adjust API docs (API.md or dedicated README section) describing the new /resolved variant and optional query flag, noting authentication and
        (b) resolved variant expands annotations/collections, (c) failed dependency surfaces an error. Use lightweight fixtures to keep tests network-free.
  - Validation regimen

• Plan
  - Design the enhancement: add a /resolved variant (and optional query flag) that drives a shared resolver which fetches annotations/bodies/collections
    from TinyPEN/RERUM, embeds them, and handles upstream errors cleanly.
  - Implement the resolver + routing changes, update docs/JSDoc as needed, and create/extend Jest coverage for both legacy and resolved behaviors—making
    sure to run manual integration checks against http://localhost:3012 with the provided token before touching any npm run … suites.
  - After manual verification passes, execute npm run allTests (and any faster subsets if useful) to confirm nothing regressed, then summarize the work for
    the draft PR targeting 382-fully-resolved-page.


─ Worked for 11m 52s ─────────────────

• Changes

  - Wired the page router to a shared handleGetPage flow so the legacy /project/:projectId/page/:pageId response stays untouched while /project/:projectId/page/:pageId/
    resolved and the ?resolved=true query flag now emit the enriched payload; request gating lives in page/index.js:17-134 so both code paths reuse the same formatting
    and error handling.
  - Added page/resolveAnnotationPage.js:1-87, which clones the AnnotationPage payload, fetches every RERUM-based annotation and partOf collection, and recursively
    resolves annotation bodies; HTTP failures propagate with the right status codes so the route can fail RESTfully.
  - Created page/__tests__/resolveAnnotationPage.test.js:1-51 to pin down resolver behavior (successful embed vs. fetch failure) by mocking global.fetch; missing jest
    import surfaced on the first run, so the suite now imports jest explicitly.
  - Documented the new /resolved path and query flag plus the fully-resolved semantics in API.md:380-411.

  Testing

  - Manual (after pm2 restart ecosystem.config.json --env development --cwd .):
      - curl http://localhost:3012/project/691baec77a801d235f346df5/page/691baec77a801d235f346df7 (Bearer token) → 200 with the original reference-only payload.
      - curl http://localhost:3012/project/691baec77a801d235f346df5/page/691baec77a801d235f346df7/resolved → 200 with embedded annotation bodies and collection data.
      - curl http://localhost:3012/project/691baec77a801d235f346df5/page/691baec77a801d235f346df7?resolved=true → 200 matching the /resolved payload.
  - Automated: npm run allTests → PASS (expected warnings about missing .env.test; first attempt failed only because the new test lacked import { jest } from '@jest/
    globals').

  Next Steps

  1. Open the draft PR against 382-fully-resolved-page, calling out the manual curls plus npm run allTests evidence.
  2. Consider whether we want to batch TinyPEN lookups (or cache resolved payloads) if we start resolving large collections; right now every annotation generates its
     own fetch.


```