### PR TITLE
Validate PATCH /line/:lineid/bounds requests

### DIFF
--- a/classes/Line/Line.js
+++ b/classes/Line/Line.js
@@ -180,10 +180,11 @@ export default class Line {
     }
 
     async updateBounds({x, y, w, h}, options = {}) {
-        const isValidBound = v => Number.isInteger(v) && v >= 0
+        const isValidBound = v => (Number.isInteger(v) && v >= 0) || (typeof v === 'string' && /^\d+$/.test(v))
         if (!isValidBound(x) || !isValidBound(y) || !isValidBound(w) || !isValidBound(h)) {
             throw new Error('Bounds ({x,y,w,h}) must be non-negative integers')
         }
+        x = parseInt(x, 10); y = parseInt(y, 10); w = parseInt(w, 10); h = parseInt(h, 10)
         if (options.creator) this.creator = options.creator
         this.target ??= ''
         const newTarget = this.updateTargetXYWH(this.target, x, y, w, h)

--- a/line/index.js
+++ b/line/index.js
@@ -270,10 +270,11 @@ router.patch('/:lineId/bounds', auth0Middleware(), async (req, res) => {
     if (!(await projectObj.checkUserAccess(user._id, ACTIONS.UPDATE, SCOPES.SELECTOR, ENTITIES.LINE))) {
       return respondWithError(res, 403, 'You do not have permission to update line bounds in this project')
     }
-    const isValidBound = v => Number.isInteger(v) && v >= 0
-    if (typeof req.body !== 'object' || !isValidBound(req.body.x) || !isValidBound(req.body.y) || !isValidBound(req.body.w) || !isValidBound(req.body.h)) {
+    const isValidBound = v => (Number.isInteger(v) && v >= 0) || (typeof v === 'string' && /^\d+$/.test(v))
+    if (!req.body || typeof req.body !== 'object' || Array.isArray(req.body) || !isValidBound(req.body.x) || !isValidBound(req.body.y) || !isValidBound(req.body.w) || !isValidBound(req.body.h)) {
       return respondWithError(res, 400, 'Invalid request body. Expected an object with x, y, w, and h as non-negative integers.')
     }
+    const bounds = { x: parseInt(req.body.x, 10), y: parseInt(req.body.y, 10), w: parseInt(req.body.w, 10), h: parseInt(req.body.h, 10) }
     const project = await getProjectById(req.params.projectId)
     const page = await findPageById(req.params.pageId, req.params.projectId)
     const findOldLine = page.items?.find(l => l.id.split('/').pop() === req.params.lineId?.split('/').pop())
@@ -284,7 +285,7 @@ router.patch('/:lineId/bounds', auth0Middleware(), async (req, res) => {
     let oldLine = await fetch(findOldLine.id).then(res => res.json())
     delete oldLine.label
     const line = new Line(oldLine)
-    const updatedLine = await line.updateBounds(req.body, { creator: user._id })
+    const updatedLine = await line.updateBounds(bounds, { creator: user._id })
     const lineIndex = page.items.findIndex(l => l.id.split('/').pop() === req.params.lineId?.split('/').pop())
     page.items[lineIndex] = updatedLine
 


### PR DESCRIPTION
Closes #342 
Closes #355
Closes #432 

## Summary
- Replaced loose falsy checks (`!x || !y || !w || !h`) with strict validation requiring non-negative integers or digit-only strings
- Added `parseInt()` coercion so validated string values (e.g. `"100"`) are converted to integers before reaching `updateTargetXYWH()`
- Added `null` and `Array` body guards in the route handler to return a proper 400 instead of 500
- Applied validation defense-in-depth at both the route handler (`line/index.js`) and domain model (`classes/Line/Line.js`)

## What was wrong
The `PATCH /:lineId/bounds` endpoint and `Line.updateBounds()` accepted arbitrary values for `x`, `y`, `w`, and `h` properties. Improper or malicious value strings could be passed through and interpolated into IIIF fragment selectors (`#xywh=pixel:${x},${y},${w},${h}`), potentially ending up in HTML.

## What changed
- `isValidBound` checks `Number.isInteger(v) && v >= 0` for integers and `/^\d+$/.test(v)` for string representations
- Validated values are coerced to integers via `parseInt(v, 10)` before any downstream use
- Route-level guards added for `null` body and `Array` body edge cases

## Test plan
- [ ] Valid integer bounds (`{ x: 20, y: 20, w: 200, h: 200 }`) accepted as before
- [ ] Valid string integer bounds (`{ x: "20", y: "20", w: "200", h: "200" }`) accepted and coerced
- [ ] Zero origin (`{ x: 0, y: 0, w: 100, h: 100 }`) now accepted (previously rejected as falsy)
- [ ] Malicious strings (`{ x: "<script>alert(1)</script>", ... }`) rejected with 400
- [ ] Negative values (`{ x: -1, ... }`) rejected with 400
- [ ] Float values (`{ x: 1.5, ... }`) rejected with 400
- [ ] `null` JSON body returns 400, not 500