### PR TITLE
407 update updates

### DIFF
--- a/classes/Group/Group.js
+++ b/classes/Group/Group.js
@@ -68,8 +68,9 @@ export default class Group {
      * Replace all roles for a member with the provided roles.
      * @param {String} memberId _id of the member
      * @param {Array | String} roles [ROLE, ROLE, ...] or "ROLE ROLE ..."
+     * @param {boolean} shouldUpdate Persist changes when true
      */
-    async setMemberRoles(memberId, roles) {
+    async setMemberRoles(memberId, roles, shouldUpdate = true) {
         if (!Object.keys(this.data.members).length) {
             await this.#loadFromDB()
         }
@@ -92,7 +93,9 @@ export default class Group {
 
         roles = washRoles(roles)
         this.data.members[memberId].roles = roles
-        await this.update()
+        if (shouldUpdate) {
+            await this.update()
+        }
     }
 
     /**
@@ -133,8 +136,10 @@ export default class Group {
      * Remove roles if found for a member.
      * @param {String} memberId _id of the member
      * @param {Array | String} roles [ROLE, ROLE, ...] or "ROLE ROLE ..."
+     * @param {boolean} allowOwner Allow removal of OWNER role
+     * @param {boolean} shouldUpdate Persist changes when true
      */
-    async removeMemberRoles(memberId, roles, allowOwner = false) {
+    async removeMemberRoles(memberId, roles, allowOwner = false, shouldUpdate = true) {
         if (!Object.keys(this.data.members).length) {
             await this.#loadFromDB()
         }
@@ -163,7 +168,9 @@ export default class Group {
         }
 
         this.data.members[memberId].roles = this.data.members[memberId].roles.filter(role => !roles.includes(role))
-        await this.update()
+        if (shouldUpdate) {
+            await this.update()
+        }
     }
 
     /**

--- a/classes/Project/Project.js
+++ b/classes/Project/Project.js
@@ -235,7 +235,6 @@ export default class Project {
       const user = new User(userId)
       const userData = await user.getSelf()
       await group.removeMember(userId, voluntary)
-      await group.update()
       const projectTitle = this.data?.label ?? this.data?.title ?? 'TPEN Project'
       try {
         // Send confirmation email (non-blocking)

--- a/project/memberRouter.js
+++ b/project/memberRouter.js
@@ -72,7 +72,6 @@ router.route("/:projectId/collaborator/:collaboratorId/addRoles").post(auth0Midd
     const groupId = projectObj.data.group
     const group = new Group(groupId)
     await group.addMemberRoles(collaboratorId, roles)
-    await group.update()
     res.status(200).send(`Roles added to member ${collaboratorId}.`)
   } catch (error) {
     return respondWithError(res, error.status ?? 500, error.message ?? "Error adding roles to member.")
@@ -137,9 +136,9 @@ router.route("/:projectId/switch/owner").post(auth0Middleware(), async (req, res
     }
     const group = new Group(projectObj.data.group)
     const currentRoles = await group.getMemberRoles(user._id)
-    Object.keys(currentRoles).length === 1 && await group.addMemberRoles(user._id, ["CONTRIBUTOR"])
-    await group.addMemberRoles(newOwnerId, ["OWNER"], true)
-    await group.removeMemberRoles(user._id, ["OWNER"], true)
+    Object.keys(currentRoles).length === 1 && await group.addMemberRoles(user._id, ["CONTRIBUTOR"], false, false)
+    await group.addMemberRoles(newOwnerId, ["OWNER"], true, false)
+    await group.removeMemberRoles(user._id, ["OWNER"], true, false)
     await group.update()
     res.status(200).json({ message: `Ownership successfully transferred to member ${newOwnerId}.` })
   } catch (error) {


### PR DESCRIPTION
This pull request refactors the role management methods in the `Group` class to allow more granular control over when changes are persisted to the database. It introduces a new `shouldUpdate` parameter to key methods, enabling callers to decide whether to immediately persist changes or defer updates. This change reduces redundant database writes and simplifies related router and project logic.

### Role management API improvements

* Added a `shouldUpdate` parameter (defaulting to `true`) to `setMemberRoles`, `addMemberRoles`, `removeMemberRoles`, and `removeMember` methods in `Group.js`, allowing control over whether changes are persisted immediately. [[1]](diffhunk://#diff-e7d9a8bed14071def306736a49c7738e1b62491ebfa888e796f128ddd928140bR71-R73) [[2]](diffhunk://#diff-e7d9a8bed14071def306736a49c7738e1b62491ebfa888e796f128ddd928140bR96-R108) [[3]](diffhunk://#diff-e7d9a8bed14071def306736a49c7738e1b62491ebfa888e796f128ddd928140bL125-R142) [[4]](diffhunk://#diff-e7d9a8bed14071def306736a49c7738e1b62491ebfa888e796f128ddd928140bR171-R174) [[5]](diffhunk://#diff-e7d9a8bed14071def306736a49c7738e1b62491ebfa888e796f128ddd928140bR185-R187) [[6]](diffhunk://#diff-e7d9a8bed14071def306736a49c7738e1b62491ebfa888e796f128ddd928140bL199-R212)
* Updated internal logic in `Group.js` to conditionally call `update()` based on `shouldUpdate`, reducing unnecessary database operations. [[1]](diffhunk://#diff-e7d9a8bed14071def306736a49c7738e1b62491ebfa888e796f128ddd928140bL125-R142) [[2]](diffhunk://#diff-e7d9a8bed14071def306736a49c7738e1b62491ebfa888e796f128ddd928140bR171-R174) [[3]](diffhunk://#diff-e7d9a8bed14071def306736a49c7738e1b62491ebfa888e796f128ddd928140bL199-R212)

### Integration and usage updates

* Modified calls to `addMemberRoles` in `Group.js` to pass `shouldUpdate = false` when used in initialization logic, preventing redundant updates.
* Removed redundant `update()` calls in `Project.js` and `project/memberRouter.js` since updates are now handled within the role management methods when appropriate. [[1]](diffhunk://#diff-7af12083079f39977c3d7623271bf279501b7257fac518b37bf663eb0c5e2f71L238) [[2]](diffhunk://#diff-a83f361be85722f8f235e1b539571ebd5f6294e7a20767f8dd0502abe2680a37L75)
* Updated router logic for ownership transfer to use the new `shouldUpdate` parameter, deferring updates until all role changes are complete.