### PR TITLE
Fix PUT /page/:pageid Column Generation Behavior

### DIFF
--- a/page/index.js
+++ b/page/index.js
@@ -185,37 +185,26 @@ router.route('/:pageId')
               }
             }
           }
-          if (!oldId.startsWith(process.env.RERUMIDPREFIX)) {
+          const columnToUpdate = pageColumnsUpdate?.find(col => col.lines.includes(newId))
+          if (columnToUpdate) {
+            const columnDB = new Column(columnToUpdate.id)
+            const columnData = await columnDB.getColumnData()
             const splitIdsEntry = splitIds.find(pair => Object.keys(pair)[0] === newId)
-            const newColumnRecord = await Column.createNewColumn(pageId, projectId, null, [newId, ...(splitIdsEntry ? splitIdsEntry[newId] : [])])
-            const newColumn = {
-              id: newColumnRecord._id,
-              label: newColumnRecord.label,
-              lines: newColumnRecord.lines
-            }
-            pageColumnsUpdate = pageColumnsUpdate ? [...pageColumnsUpdate, newColumn] : [newColumn]
-          } else {
-            const columnToUpdate = pageColumnsUpdate.find(col => col.lines.includes(newId))
-            if (columnToUpdate) {
-              const columnDB = new Column(columnToUpdate.id)
-              const columnData = await columnDB.getColumnData()
-              const splitIdsEntry = splitIds.find(pair => Object.keys(pair)[0] === newId)
-              if (splitIdsEntry) {
-                const dateIds = splitIdsEntry[newId]
-                columnData.lines.push(...dateIds)
-                columnDB.data = columnData
-                await columnDB.update()
-                pageColumnsUpdate = pageColumnsUpdate.map(col => {
-                  if (col.id === columnToUpdate.id) {
-                    return {
-                      id: columnToUpdate.id,
-                      label: columnToUpdate.label,
-                      lines: columnData.lines
-                    }
+            if (splitIdsEntry) {
+              const dateIds = splitIdsEntry[newId]
+              columnData.lines.push(...dateIds)
+              columnDB.data = columnData
+              await columnDB.update()
+              pageColumnsUpdate = pageColumnsUpdate.map(col => {
+                if (col.id === columnToUpdate.id) {
+                  return {
+                    id: columnToUpdate.id,
+                    label: columnToUpdate.label,
+                    lines: columnData.lines
                   }
-                  return col
-                })
-              }
+                }
+                return col
+              })
             }
           }
         }


### PR DESCRIPTION
Closes #502.

PUT `/page/:pageId` was creating one new column per new line item. This was observed when the "Detect Lines" prompts submit all lines in a single PUT, which produced N single-line columns whose order had no relationship to reading order — breaking line-by-line navigation.

## Change

Removed the auto-column-create branch in the `updatedItemsList` loop and unwrapped the surrounding `else` so the split-into-existing-column logic runs unconditionally.

## Preserved behavior

- Existing-column line-id remapping when RERUM versions a changed line.
- Splitting a RERUM-tracked line: numeric date-id children are appended to the parent's column.
- Line deletion: dropped lines leave their column; empty columns are deleted.
- Explicit column creation via `POST /page/:pageId/column` is unchanged.

## Side effect

`pageColumnsUpdate.find(...)` is now `pageColumnsUpdate?.find(...)`. The new block runs for every `updatedItemsList` entry, so the variable can legitimately be `null` (column-less page). Closes a latent null-deref on column-less pages whose lines get RERUM-versioned by a PUT.

## Manual testing

| # | Scenario | Starting state | Request | Result |
|---|---|---|---|---|
| 1 | Bulk-create on a page with one column | 1 line, 1 column (`A`) | echo existing line + 2 brand-new lines | ✅ 3 items, `Column A` unchanged, no new columns |
| 2 | Single-column split | continued from 1 | parent line (body change) + 2 numeric date-id children + 2 preserved lines | ✅ 5 items; `Column A` tracked new parent URI and gained both split children |
| 3 | Line deletion from a column | continued from 2 | 4 items; one column-tracked child omitted | ✅ Column dropped the omitted child; tracked new URIs for the rest |
| 4 | No-op PUT (re-versioning guard) | reset: 1 line, 1 column | same id + same target, no body | ✅ URI unchanged — `hasAnnotationChanges` correctly skipped re-versioning |
| 5 | Multi-column split with brand-new line in same PUT | reset: 2 lines, 2 columns (`A`, `B`) | `A` (body edit) + numeric child for A; `B` (body edit) + numeric child for B; 1 brand-new line | ✅ Both columns tracked their new parent URI and gained their own child only; brand-new line created no third column |
| 6 | Bulk-create on a column-less page | different page: 1 line, 0 columns | echo existing line + 5 brand-new lines | ✅ 6 items in submission order; `columns` still `null`; existing URI preserved (target unchanged); the new `pageColumnsUpdate?.find(...)` null-safety branch exercised |

