### PR TITLE
Fix History Tool URL — use github-pages tpen-line-history

### DIFF
--- a/classes/Tools/Tools.js
+++ b/classes/Tools/Tools.js
@@ -214,11 +214,11 @@ export default class Tools {
         {
             "label": "History Tool",
             "toolName": "history",
-            "custom": { 
-                "enabled": true, 
+            "custom": {
+                "enabled": true,
                 "tagName": "tpen-line-history"
             },
-            "url": "https://app.t-pen.org/components/line-history/index.js",
+            "url": "https://centerfordigitalhumanities.github.io/tpen-line-history/tpen-line-history.js",
             "location": "pane"
         },
         {


### PR DESCRIPTION
## Summary

Fix the broken Line History tool URL in `Tools.defaultTools`. The previous URL `https://app.t-pen.org/components/line-history/index.js` 404s — that file was deleted from `tpen3-interfaces` in commit `1c25cbe` (Feb 2026). The replacement points at the github-pages build of the dedicated `tpen-line-history` repo, which still publishes a working `tpen-line-history` custom element.

This change rides along with the broader TPEN ↔ tool messaging contract cleanup (see CenterForDigitalHumanities/TPEN-interfaces#564 for the full story) but is independent of the protocol changes and could ship on its own.

## Changes

- `classes/Tools/Tools.js` — `Tools.defaultTools` "History Tool" entry: `url` changed from `https://app.t-pen.org/components/line-history/index.js` to `https://centerfordigitalhumanities.github.io/tpen-line-history/tpen-line-history.js`. `tagName` (`tpen-line-history`), `custom.enabled` (`true`), and `location` (`pane`) unchanged. Loads as a custom element, not an iframe.

## Coordinated cut

The other repos in this set are protocol changes; this PR is the registry fix that unblocks the History tool. Cross-repo PR list:

- TPEN-interfaces (authority): https://github.com/CenterForDigitalHumanities/TPEN-interfaces/pull/564
- Page-Viewer: https://github.com/CenterForDigitalHumanities/Page-Viewer/pull/14
- Preview-Transcription: https://github.com/CenterForDigitalHumanities/Preview-Transcription/pull/6
- Line-Breaking: https://github.com/CenterForDigitalHumanities/Line-Breaking/pull/2
- Compare-Pages: https://github.com/CenterForDigitalHumanities/Compare-Pages/pull/3
- TPEN-Prompts: https://github.com/CenterForDigitalHumanities/TPEN-Prompts/pull/16

## Test plan

Developer-validated locally on 2026-05-08:

- [x] `npm run allTests` passes — 187/187 ✅ (113 integration tests skipped, as expected without a live test stack).
- [x] In TPEN-interfaces, opened `/transcribe` against a project with the History tool, confirmed the custom element loads in the pane (no 404 in console). Live-line tracking on the local stack is gated on CenterForDigitalHumanities/tpen-line-history#5 (the tool hardcodes `https://app.t-pen.org/api/TPEN.js`, so its TPEN module instance is siloed from the local interfaces' module instance — works on prod where the URLs dedupe).

## Companion follow-up (deferred, does not block this cut)

- CenterForDigitalHumanities/tpen-line-history#5 — hardcoded prod TPEN module URL prevents local-stack and dev-stack testing of live line tracking. The URL fix in this PR is independent and lands the script load successfully.